### PR TITLE
Potential Fix for incorrect map size in river generation

### DIFF
--- a/1.2/Source/MapDesigner/Patches/RiverStylePatch.cs
+++ b/1.2/Source/MapDesigner/Patches/RiverStylePatch.cs
@@ -11,26 +11,42 @@ using Verse.Noise;
 
 namespace MapDesigner.Patches
 {
+    public static class MapGenSize
+    {
+        public static IntVec3 mapgensize { get; set; }
+    }
+
+    [HarmonyPatch(typeof(Verse.MapGenerator), "GenerateMap")]
+    static class SetMapGenSize
+    {
+        static void Prefix(IntVec3 mapSize)
+        {
+            MapGenSize.mapgensize = mapSize;
+        }
+    }
+
     [HarmonyPatch(typeof(RimWorld.RiverMaker))]
     [HarmonyPatch(MethodType.Constructor)]
     [HarmonyPatch(new Type[] { typeof(Vector3), typeof(float), typeof(RiverDef) })]
     static class RiverStylePatch
     {
 
-        static bool Prefix (ref Vector3 center)
+        static bool Prefix(ref Vector3 center)
         {
             if (MapDesignerMod.mod.settings.flagRiverLoc)
             {
-                if(MapDesignerMod.mod.settings.flagRiverLocAbs)
+                if (MapDesignerMod.mod.settings.flagRiverLocAbs)
                 {
-                    center.x =  Find.World.info.initialMapSize.x * (0.5f + MapDesignerMod.mod.settings.riverCenterDisp.x);
-                    center.z = Find.World.info.initialMapSize.z * (0.5f + MapDesignerMod.mod.settings.riverCenterDisp.z);
+                    center.x = MapGenSize.mapgensize.x * (0.5f + MapDesignerMod.mod.settings.riverCenterDisp.x);
+                    center.z = MapGenSize.mapgensize.z * (0.5f + MapDesignerMod.mod.settings.riverCenterDisp.z);
                 }
                 else
                 {
-                    center.x += Find.World.info.initialMapSize.x * MapDesignerMod.mod.settings.riverCenterDisp.x;
-                    center.z += Find.World.info.initialMapSize.z * MapDesignerMod.mod.settings.riverCenterDisp.z;
+                    center.x += MapGenSize.mapgensize.x * MapDesignerMod.mod.settings.riverCenterDisp.x;
+                    center.z += MapGenSize.mapgensize.z * MapDesignerMod.mod.settings.riverCenterDisp.z;
                 }
+                center.x -= 0.5f;
+                center.z -= 0.5f;
             }
 
             return true;

--- a/1.3/Source/MapDesigner/Patches/RiverStylePatch.cs
+++ b/1.3/Source/MapDesigner/Patches/RiverStylePatch.cs
@@ -11,26 +11,39 @@ using Verse.Noise;
 
 namespace MapDesigner.Patches
 {
+    public static class MapGenSize
+    {
+        public static IntVec3 mapgensize { get; set; }
+    }
+
+    [HarmonyPatch(typeof(Verse.MapGenerator), "GenerateMap")]
+    static class SetMapGenSize
+    {
+        static void Prefix(IntVec3 mapSize)
+        {
+            MapGenSize.mapgensize = mapSize;
+        }
+    }
+
     [HarmonyPatch(typeof(RimWorld.RiverMaker))]
     [HarmonyPatch(MethodType.Constructor)]
     [HarmonyPatch(new Type[] { typeof(Vector3), typeof(float), typeof(RiverDef) })]
     static class RiverStylePatch
     {
 
-        static bool Prefix (ref Vector3 center)
+        static bool Prefix(ref Vector3 center)
         {
             if (MapDesignerMod.mod.settings.flagRiverLoc)
             {
-                if(MapDesignerMod.mod.settings.flagRiverLocAbs)
+                if (MapDesignerMod.mod.settings.flagRiverLocAbs)
                 {
-                    center.x =  Find.World.info.initialMapSize.x * (0.5f + MapDesignerMod.mod.settings.riverCenterDisp.x);
-                    center.z = Find.World.info.initialMapSize.z * (0.5f + MapDesignerMod.mod.settings.riverCenterDisp.z);
-          
+                    center.x = MapGenSize.mapgensize.x * (0.5f + MapDesignerMod.mod.settings.riverCenterDisp.x);
+                    center.z = MapGenSize.mapgensize.z * (0.5f + MapDesignerMod.mod.settings.riverCenterDisp.z);
                 }
                 else
                 {
-                    center.x += Find.World.info.initialMapSize.x * MapDesignerMod.mod.settings.riverCenterDisp.x;
-                    center.z += Find.World.info.initialMapSize.z * MapDesignerMod.mod.settings.riverCenterDisp.z;
+                    center.x += MapGenSize.mapgensize.x * MapDesignerMod.mod.settings.riverCenterDisp.x;
+                    center.z += MapGenSize.mapgensize.z * MapDesignerMod.mod.settings.riverCenterDisp.z;
                 }
                 center.x -= 0.5f;
                 center.z -= 0.5f;


### PR DESCRIPTION
I believe the below should fix the issues with the river position in map generation for anything other than default (250x250) map size.

It does this by creating a new variable that can be set by our code - mapgensize.

A Prefix Harmony Patch, SetMapGenSize is then run when the GenerateMap method within MapGenerator is called. This captures the map size passed to the GenerateMap method (IntVec3 variable mapSize), and then sets the public variable we created earlier to this value.

Finally within the RiverStylePatch Prefix, rather than using Find.World.info.initialMapSize, it now uses the mapgensize variable that was captured and set to get the accurate map size for what is being generated.